### PR TITLE
[TOF-261] Depois que morre pela primeira vez a animação de morte fica flicando

### DIFF
--- a/Assets/_Scripts/Player/DeathToRespawnBehaviour.cs
+++ b/Assets/_Scripts/Player/DeathToRespawnBehaviour.cs
@@ -19,9 +19,11 @@ public class DeathToRespawnBehaviour : StateMachineBehaviour
     // OnStateExit is called when a transition ends and the state machine finishes evaluating this state
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        LevelDataManager.Instance.Respawn(animator.transform.parent.gameObject);
+        if (animator == null) return;
+
         animator.Rebind();
         animator.Update(0f);
+        LevelDataManager.Instance.Respawn(animator.transform.parent.gameObject);
     }
 
     // OnStateMove is called right after Animator.OnAnimatorMove()


### PR DESCRIPTION
### Jira ticket

https://pinealpple-studios.atlassian.net/browse/TOF-261

### Problema

Depois que o jogador morria pela primeira vez a animação de morte ficava executando diversas vezes;

### Descrição

A ordem para reiniciar os estados do Animator (Máquina de estados da animação) estava sendo executada no momento que o animator estava desativado, portanto guardando sujeira do estado anterior, aqui apenas trocamos a ordem para que o Rebind aconteça antes do componente estar inativo;

### Testes

```
Eu como Player
Pulei até um inimigo 
E forcei uma morte
Ao reviver
Eu ataquei
Então a animação de morte não foi mais executada
```

### Screenshot


https://github.com/Pineapple-Studios/tears-of-fire/assets/16820917/4f1d0975-58a6-46f7-84a3-35968eb96569



